### PR TITLE
Implement UTF handling in escapes for use in yes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Either `dub build` to use dub or `./build.sh` to use meson.
 ## Done and Documented with a manpage but needs i18n ##
 
 * dirname (1dunex)
+* yes
 
 ## (Mostly) Done but needs documentation ##
 
@@ -16,8 +17,7 @@ Either `dub build` to use dub or `./build.sh` to use meson.
 * mkfifo
 * ddate
 
-## Done but needs porting to command framework ## 
-* yes
+## Done but needs porting to command framework ##
 * tee
 * tty
 * echo

--- a/doc/man/yes.1.md
+++ b/doc/man/yes.1.md
@@ -14,6 +14,7 @@ DESCRIPTION
 ===========
 
 Repeatedly prints the string specified on the command line. If no string is provided, prints 'y' instead.
+Can be used to print arbitrary UTF-8 characters with the format '\\uNNNN'.
 
 FLAGS
 =====
@@ -37,3 +38,5 @@ dunex-core Version 1.0
 
 SEE ALSO
 ========
+
+**dunex-core(7dunex)** **dunex(7dunex)**

--- a/src/common/escapes.d
+++ b/src/common/escapes.d
@@ -4,8 +4,8 @@
 	Boost Software License, Version 1.0.  (See accompanying file
 	COPYING or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-	Author(s): chaomodus
-	2019-11-29T17:43:11
+	Author(s): chaomodus, Marie-Joseph
+	2020-05-01T01:33
 
 	This implements decoding common character escapes.
 
@@ -18,6 +18,10 @@ module escapes;
 import std.algorithm;
 import std.array;
 import std.string;
+
+import std.range : take, popFrontN;
+import std.conv : to;
+import std.utf : toUTF8;
 
 /***********************************
  * decode escaped character in the input string
@@ -64,6 +68,14 @@ import std.string;
 				break;
 			case 'r':
 				ret ~= "\r";
+				break;
+			case 'u':
+				if (inp.length >= 4) {
+					ret ~= inp.take(4).to!int(16).to!wchar.to!string.toUTF8();
+					inp.popFrontN(4);
+				} else {
+					ret ~= "u";
+				}
 				break;
 			case 'v':
 				ret ~= "\v";

--- a/src/common/escapes.d
+++ b/src/common/escapes.d
@@ -17,10 +17,9 @@ module escapes;
 
 import std.algorithm;
 import std.array;
-import std.string;
-
-import std.range : take, popFrontN;
 import std.conv : to;
+import std.range : take, popFrontN;
+import std.string;
 import std.utf : toUTF8;
 
 /***********************************
@@ -71,12 +70,13 @@ import std.utf : toUTF8;
 				break;
 			case 'u':
 				if (inp.length >= 4) {
-					ret ~= inp.take(4).to!int(16).to!wchar.to!string.toUTF8();
-					inp.popFrontN(4);
-				} else {
-					ret ~= "u";
+					try {
+						ret ~= inp.take(4).to!int(16).to!wchar.to!string.toUTF8();
+						inp.popFrontN(4);
+						break;
+					} catch (Exception ex) {}
 				}
-				break;
+				goto default;
 			case 'v':
 				ret ~= "\v";
 				break;

--- a/src/yes/yes.d
+++ b/src/yes/yes.d
@@ -15,6 +15,7 @@ import std.stdio : write, stderr;
 import std.array : join;
 
 import common.cmd;
+import common.escapes;
 
 enum APP_NAME = "yes";
 enum APP_DESC = "Repeatedly print the specified string or 'y'.";
@@ -31,16 +32,11 @@ int main(string[] args) {
         (ProgramArgs args) {
             try {
                 string nl = args.flag("noNewline") ? "" : "\n";
+                string argsToPrint = args.arg("string").length == 0 ? "y" : decodeEscapes(args.args("string").join(" "));
 
-                if (args.arg("string").length == 0) {
-                    while (true)
-                        write("y", nl);
-                } else {
-                    string joined_args = args.args("string").join(" ");
-                    while (true) {
-                        write(joined_args, nl);
-                    }
-                }
+                while (true)
+                    write(argsToPrint, nl);
+
             } catch(Exception ex) {
                 stderr.writeln(APP_NAME, ": ", ex.msg);
                 return 1;

--- a/src/yes/yes.d
+++ b/src/yes/yes.d
@@ -11,11 +11,11 @@
 
 module app;
 
-import std.stdio : write, stderr;
-import std.array : join;
-
 import common.cmd;
 import common.escapes;
+
+import std.stdio : write, stderr;
+import std.array : join;
 
 enum APP_NAME = "yes";
 enum APP_DESC = "Repeatedly print the specified string or 'y'.";


### PR DESCRIPTION
Changes
=======

README.md:
* Updated the status of `yes`

yes.d:
* Cleaned up implementation
* Arranged new imports in lexicographic order to align with D suggested style
* Added escapes handling via `decodeEscapes`

escapes.d:
* Added UTF-8 handling

yes.1.md:
* Added mention of UTF-8 handling
* Added boilerplate SEE ALSO entries