### PR TITLE
Add ddate docs, update README, clarify yes.1.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@ At current time the implementations are more like the FreeBSD core utilities.
 
 Either `dub build` to use dub or `./build.sh` to use meson.
 
-## Done and Documented with a manpage but needs i18n ##
+## Done and documented with a manpage but needs i18n ##
 
+* ddate (1dunex)
 * dirname (1dunex)
-* yes
+* mkfifo (1dunex)
+* yes (1dunex)
 
 ## (Mostly) Done but needs documentation ##
 
 * nl (missing a weird little feature but should be easy to implement)
-* mkfifo
-* ddate
 
 ## Done but needs porting to command framework ##
 * tee

--- a/doc/man/ddate.1.md
+++ b/doc/man/ddate.1.md
@@ -1,0 +1,56 @@
+% DDATE(1dunex) Version 1.0 | DUNEX Core
+
+NAME
+====
+
+**ddate** - return the date in the Discordian calendar.
+
+SYNOPSIS
+========
+
+| **ddate** [_FORMAT_]...
+
+DESCRIPTION
+===========
+
+Returns the current date in the Discordian calendar, optionally in a specific format.
+
+FORMAT
+======
+
+ **%D** - ESO 1dd1293 standard format (default)
+
+ **%n** - Season number from 1 to 5
+
+ **%S** - Season name
+
+ **%r** - short season name
+
+ **%w** - day of week number from 1 to 5
+
+ **%W** - day of week name
+
+ **%R** - short day of week name
+
+ **%d** - day number of season
+
+ **%o** - ordinal ('Nth') day number of season
+
+ **%y** - year number
+
+AUTHOR
+======
+
+chaomodus
+
+INTEGRATION
+===========
+
+Part of the DUNEX System
+
+dunex-core Version 1.0
+
+SEE ALSO
+========
+
+**dunex-core(7dunex)** **dunex(7dunex)**

--- a/doc/man/yes.1.md
+++ b/doc/man/yes.1.md
@@ -14,7 +14,10 @@ DESCRIPTION
 ===========
 
 Repeatedly prints the string specified on the command line. If no string is provided, prints 'y' instead.
-Can be used to print arbitrary UTF-8 characters with the format '\\uNNNN'.
+
+This implementation passes through properly escaped command characters; e.g.
+'\\t' will be a tab or '\\uHHHH' will be the UTF-8 character represented by that
+hexadecimal code.
 
 FLAGS
 =====


### PR DESCRIPTION
# Changes

README.md:
* moved mkfifo and ddate to "done and documented"
* add manpage section next to util names in "done and documented" section

doc/man/ddate.1.md:
* Created documentation for ddate util

doc/man/yes.1.md:
* Clarified the functionality of escape handling somewhat